### PR TITLE
updated barcode feature

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -130,7 +130,7 @@
 
 	<script>
       {% if template contains 'product' %}
-      var variant_data_object = { {% for variant in product.variants %}variant_{{ variant.id }}:'{{ variant.metafields.custom.variant_barcode }}'{% unless forloop.last == true %},{% endunless %} {% endfor %} }          
+      var variant_data_object = { {% for variant in product.variants %}variant_{{ variant.id }}:'{{ variant.barcode }}'{% unless forloop.last == true %},{% endunless %} {% endfor %} }          
       {% else %}
       var variant_data_object ={};
       {% endif %}

--- a/layout/theme.shogun.landing.liquid
+++ b/layout/theme.shogun.landing.liquid
@@ -137,7 +137,7 @@ This file can be re-written at any time.
 
 	<script>
       {% if template contains 'product' %}
-      var variant_data_object = { {% for variant in product.variants %}variant_{{ variant.id }}:'{{ variant.metafields.custom.variant_barcode }}'{% unless forloop.last == true %},{% endunless %} {% endfor %} }          
+      var variant_data_object = { {% for variant in product.variants %}variant_{{ variant.id }}:'{{ variant.barcode }}'{% unless forloop.last == true %},{% endunless %} {% endfor %} }          
       {% else %}
       var variant_data_object ={};
       {% endif %}

--- a/sections/product-template-ace-cart.liquid
+++ b/sections/product-template-ace-cart.liquid
@@ -320,7 +320,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-cazador-cart.liquid
+++ b/sections/product-template-cazador-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                                                                      
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-fish-cart.liquid
+++ b/sections/product-template-fish-cart.liquid
@@ -320,7 +320,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                                                                    
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-fuse-cart.liquid
+++ b/sections/product-template-fuse-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                  
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-fusex-cart.liquid
+++ b/sections/product-template-fusex-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-hellcat-cart.liquid
+++ b/sections/product-template-hellcat-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-hellcatv3-cart.liquid
+++ b/sections/product-template-hellcatv3-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-lazer-cart.liquid
+++ b/sections/product-template-lazer-cart.liquid
@@ -320,7 +320,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-m5-cart.liquid
+++ b/sections/product-template-m5-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-pro-cart.liquid
+++ b/sections/product-template-pro-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-prowler-cart.liquid
+++ b/sections/product-template-prowler-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>   
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-raptor-cart.liquid
+++ b/sections/product-template-raptor-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-rocketfish-cart.liquid
+++ b/sections/product-template-rocketfish-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-wedge-cart.liquid
+++ b/sections/product-template-wedge-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                       	    <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                                                                
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-whip-cart.liquid
+++ b/sections/product-template-whip-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">

--- a/sections/product-template-whipv2-cart.liquid
+++ b/sections/product-template-whipv2-cart.liquid
@@ -321,7 +321,7 @@
                                             </div>
                                             <p class="cart-attribute__field" style="display:none;">
                                               <label for="barcode">Barcode</label>
-                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.metafields.custom.variant_barcode }}">
+                                              <input id="barcode" type="text" name="properties[Barcode]" value="{{ product.selected_or_first_available_variant.barcode }}">
                                             </p>                                        
                                         {% endform %}
                                       <div class="lazer-description-wrapper">


### PR DESCRIPTION
- originally added the metafields barcode info to the order but the client asked to revert it back to the way as it was so I updated 16 cart product templates to show the default barcode